### PR TITLE
Return promise from publish

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -387,7 +387,7 @@ Connection.prototype.publish = function (options, callback) {
   });
 
   if (!callback) {
-    deferred.promise;
+    return deferred.promise;
   }
 }
 


### PR DESCRIPTION
@jsonxr 

This fixes the publish method to actually return a promise in the event that a callback wasn't specified.
